### PR TITLE
Use authorization header instead of cookie

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,10 +67,13 @@ impl IntoResponse for ApiError {
       Self::Forbidden => (StatusCode::FORBIDDEN, self.to_string()),
       Self::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
       // Yes we want to hide internal message error from user
-      _ => (
-        StatusCode::SERVICE_UNAVAILABLE,
-        "Service unavailable".to_string(),
-      ),
+      err => {
+        tracing::error!("Error Cause: {}", err.to_string());
+        (
+          StatusCode::SERVICE_UNAVAILABLE,
+          "Service unavailable".to_string(),
+        )
+      }
     }
     .into_response();
   }

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,0 +1,33 @@
+use axum::{
+  async_trait,
+  extract::FromRequestParts,
+  http::{request::Parts, StatusCode},
+};
+
+pub struct UserToken(pub Option<String>);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for UserToken
+where
+  S: Send + Sync,
+{
+  type Rejection = (StatusCode, &'static str);
+
+  async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+    if let Some(authorization_value) = parts.headers.get("x-user-code") {
+      tracing::debug!("x-user-code header: {:?}", authorization_value);
+      if !authorization_value.is_empty() {
+        if let Ok(token) = authorization_value.to_str() {
+          if token.is_empty() {
+            return Err((
+              StatusCode::BAD_REQUEST,
+              "Authorization token must be provided",
+            ));
+          }
+          return Ok(UserToken(Some(token.to_string())));
+        }
+      }
+    }
+    Ok(UserToken(None))
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::{env, sync::Arc};
 mod database;
 mod errors;
+mod extractors;
 mod handlers;
 mod payloads;
 mod router;

--- a/src/utils/minors.rs
+++ b/src/utils/minors.rs
@@ -1,5 +1,6 @@
 use axum_extra::extract::CookieJar;
 
+#[allow(dead_code)]
 pub fn get_value_from_cookie(cookie_jar: CookieJar, key: &str) -> Option<String> {
   let cookie_value = cookie_jar.get(key);
   if cookie_value.is_none() {


### PR DESCRIPTION
For supporting multiple platforms, we need to use  `x-user-code` header in http headers to send an user_code token to server.