### PR TITLE
Websocket: changing authentication type from header to payload

### DIFF
--- a/doc/HandleChatSocket.drawio
+++ b/doc/HandleChatSocket.drawio
@@ -1,81 +1,148 @@
-<mxfile host="Electron" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.7.17 Chrome/128.0.6613.36 Electron/32.0.1 Safari/537.36" version="24.7.17">
-  <diagram name="Page-1" id="OCOAhcU6iWzB0mGFEBKq">
-    <mxGraphModel dx="2115" dy="805" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+<mxfile host="Electron" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.7.17 Chrome/128.0.6613.36 Electron/32.0.1 Safari/537.36" version="24.7.17" pages="2">
+  <diagram name="Workflow" id="OCOAhcU6iWzB0mGFEBKq">
+    <mxGraphModel dx="2386" dy="977" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="HN3X1WJZcgesYLYohcyn-1" value="WS_Sender" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="160" y="155" width="120" height="60" as="geometry" />
+        <mxCell id="kTiz112mWoVxhusgJVTT-13" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;fontColor=#333333;strokeColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="120" y="8" width="1200" height="630" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-2" value="WS_Receiver" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-1" value="WS_Sender" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="1" vertex="1">
+          <mxGeometry x="160" y="130" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="HN3X1WJZcgesYLYohcyn-2" value="WS_Receiver" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" parent="1" vertex="1">
           <mxGeometry x="160" y="293" width="120" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-3" value="" style="outlineConnect=0;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;shape=mxgraph.aws3.management_console;fillColor=#D2D3D3;gradientColor=none;" vertex="1" parent="1">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-3" value="Client" style="outlineConnect=0;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;shape=mxgraph.aws3.management_console;fillColor=#D2D3D3;gradientColor=none;" parent="1" vertex="1">
           <mxGeometry x="-20" y="230" width="63" height="63" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-4" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" target="HN3X1WJZcgesYLYohcyn-2">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-4" value="" style="endArrow=classic;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" target="HN3X1WJZcgesYLYohcyn-2" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="50" y="262" as="sourcePoint" />
             <mxPoint x="160" y="170" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-5" value="" style="endArrow=classic;html=1;rounded=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-1" target="HN3X1WJZcgesYLYohcyn-3">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-5" value="" style="endArrow=classic;html=1;rounded=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="HN3X1WJZcgesYLYohcyn-1" target="HN3X1WJZcgesYLYohcyn-3" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="90" y="140" as="sourcePoint" />
             <mxPoint x="140" y="90" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-7" value="Mapping Message" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;" vertex="1" parent="1">
-          <mxGeometry x="410" y="283" width="140" height="80" as="geometry" />
+        <mxCell id="HN3X1WJZcgesYLYohcyn-7" value="Mapping and Processing Message" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fillColor=#e1d5e7;strokeColor=#9673a6;" parent="1" vertex="1">
+          <mxGeometry x="410" y="283" width="190" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-9" value="raw&amp;nbsp;&lt;div&gt;ws message&lt;/div&gt;" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-2" target="HN3X1WJZcgesYLYohcyn-7">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-9" value="raw&amp;nbsp;&lt;div&gt;ws message&lt;/div&gt;" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="HN3X1WJZcgesYLYohcyn-2" target="HN3X1WJZcgesYLYohcyn-7" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="380" y="490" as="sourcePoint" />
             <mxPoint x="430" y="440" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-19" value="" style="endArrow=classic;html=1;rounded=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-29" target="HN3X1WJZcgesYLYohcyn-1">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-19" value="" style="endArrow=classic;html=1;rounded=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="HN3X1WJZcgesYLYohcyn-29" target="HN3X1WJZcgesYLYohcyn-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="450" y="170" as="sourcePoint" />
             <mxPoint x="500" y="120" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="850" y="160" />
+            </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-38" value="propgate message to client" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="HN3X1WJZcgesYLYohcyn-19">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-38" value="propgate message to client" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="HN3X1WJZcgesYLYohcyn-19" vertex="1" connectable="0">
           <mxGeometry x="-0.0059" y="2" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-28" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="780" y="190" width="140" height="120" as="geometry" />
+        <mxCell id="HN3X1WJZcgesYLYohcyn-28" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="780" y="215" width="140" height="120" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-29" value="Receiver" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="HN3X1WJZcgesYLYohcyn-28">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-29" value="Sender" style="rounded=1;whiteSpace=wrap;html=1;" parent="HN3X1WJZcgesYLYohcyn-28" vertex="1">
           <mxGeometry x="35" width="70" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-30" value="Shared Group channel" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;" vertex="1" parent="HN3X1WJZcgesYLYohcyn-28">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-30" value="Shared channel" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;" parent="HN3X1WJZcgesYLYohcyn-28" vertex="1">
           <mxGeometry y="30" width="140" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-31" value="&lt;div&gt;Sender&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="HN3X1WJZcgesYLYohcyn-28">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-31" value="&lt;div&gt;Receiver&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" parent="HN3X1WJZcgesYLYohcyn-28" vertex="1">
           <mxGeometry x="35" y="90" width="70" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-32" target="HN3X1WJZcgesYLYohcyn-30">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-33" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="HN3X1WJZcgesYLYohcyn-32" target="kTiz112mWoVxhusgJVTT-2" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="800" y="90" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1150" y="315" />
+            </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-37" value="send data" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="HN3X1WJZcgesYLYohcyn-33">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-37" value="Group events" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="HN3X1WJZcgesYLYohcyn-33" vertex="1" connectable="0">
           <mxGeometry x="0.0182" y="2" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-32" value="Other connection" style="ellipse;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="1030" y="210" width="120" height="80" as="geometry" />
+        <mxCell id="HN3X1WJZcgesYLYohcyn-32" value="Other connections" style="ellipse;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="1190" y="275" width="120" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="HN3X1WJZcgesYLYohcyn-36" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-7" target="HN3X1WJZcgesYLYohcyn-31">
+        <mxCell id="HN3X1WJZcgesYLYohcyn-36" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="HN3X1WJZcgesYLYohcyn-7" target="HN3X1WJZcgesYLYohcyn-31" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="690" y="460" as="sourcePoint" />
             <mxPoint x="740" y="410" as="targetPoint" />
           </mxGeometry>
         </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-1" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="980" y="300" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-2" value="Receiver" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-1">
+          <mxGeometry x="35" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-3" value="Group channel" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-1">
+          <mxGeometry y="30" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-4" value="&lt;div&gt;Sender&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-1">
+          <mxGeometry x="35" y="90" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-5" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="580" y="490" width="140" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-6" value="Receiver" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-5">
+          <mxGeometry x="35" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-7" value="Private Group channel" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-5">
+          <mxGeometry y="30" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-8" value="&lt;div&gt;Sender&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="kTiz112mWoVxhusgJVTT-5">
+          <mxGeometry x="35" y="90" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-9" value="" style="endArrow=classic;html=1;rounded=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="kTiz112mWoVxhusgJVTT-4" target="HN3X1WJZcgesYLYohcyn-31">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="900" y="120" as="sourcePoint" />
+            <mxPoint x="950" y="70" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="960" y="405" />
+              <mxPoint x="960" y="320" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-10" value="" style="endArrow=classic;html=1;rounded=0;exitX=0.625;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HN3X1WJZcgesYLYohcyn-7" target="kTiz112mWoVxhusgJVTT-6">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="320" y="570" as="sourcePoint" />
+            <mxPoint x="370" y="520" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kTiz112mWoVxhusgJVTT-11" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="kTiz112mWoVxhusgJVTT-8" target="HN3X1WJZcgesYLYohcyn-31">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="730" y="470" as="sourcePoint" />
+            <mxPoint x="1020" y="130" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="850" y="595" />
+              <mxPoint x="850" y="370" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="vkJgFCcT4Cmb6nxcTbiP" name="MessageTypeJson">
+    <mxGraphModel dx="1075" dy="684" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
       </root>
     </mxGraphModel>
   </diagram>

--- a/src/handlers/socket.rs
+++ b/src/handlers/socket.rs
@@ -1,7 +1,6 @@
 use crate::{
   errors::ApiError,
-  extractors::UserToken,
-  payloads::socket::message::{SMessageContent, SMessageType},
+  payloads::socket::message::{AuthenticateResult, SMessageContent, SMessageType},
   services::{group::check_user_join_group, message::create_new_message, user::get_user_by_code},
   AppState,
 };
@@ -14,8 +13,11 @@ use axum::{
 };
 use axum_extra::{headers::UserAgent, TypedHeader};
 use futures::{sink::SinkExt, stream::StreamExt};
-use std::{net::SocketAddr, ops::ControlFlow, sync::Arc};
-use tokio::sync::broadcast::{self, Sender};
+use std::{net::SocketAddr, ops::ControlFlow, sync::Arc, time::Duration};
+use tokio::{
+  sync::broadcast::{self, Sender},
+  time::timeout,
+};
 
 #[derive(Clone, Copy)]
 pub struct GroupSession {
@@ -27,62 +29,31 @@ pub async fn ws_group_handler(
   ws: WebSocketUpgrade,
   State(state): State<Arc<AppState>>,
   Path(group_id): Path<i32>,
-  UserToken(token): UserToken,
   user_agent: Option<TypedHeader<UserAgent>>,
   ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Result<impl IntoResponse, ApiError> {
-  // For debugging
+  // Logging connection's user agent
   let user_agent = if let Some(TypedHeader(user_agent)) = user_agent {
     user_agent.to_string()
   } else {
     "unknown".into()
   };
-  if token.is_none() {
-    return Err(ApiError::Forbidden);
-  }
   tracing::debug!("User agent: {user_agent} at {addr} connected");
-  let conn = &mut state.db_pool.get().unwrap();
-
-  // Validate user authentication and authorization
-  let user = get_user_by_code(conn, &token.unwrap())
-    .map_err(|_| ApiError::new_database_query_err("Failed to get user from user code"))?
-    .ok_or(ApiError::NotFound("User".into()))?;
-
-  if !check_user_join_group(conn, user.id, group_id).map_err(ApiError::DatabaseError)? {
-    return Err(ApiError::Unauthorized);
-  }
-  let group_session = GroupSession {
-    user_id: user.id,
-    group_id,
-  };
-
-  Ok(ws.on_upgrade(move |socket| handle_socket(socket, addr, state, group_session)))
+  Ok(ws.on_upgrade(move |socket| handle_socket(socket, addr, state, group_id)))
 }
 pub async fn handle_socket(
   socket: WebSocket,
   addr: SocketAddr,
   app_state: Arc<AppState>,
-  group_session: GroupSession,
+  group_id: i32,
 ) {
-  let GroupSession { group_id, .. } = group_session;
   let (mut socket_sender, mut socket_receiver) = socket.split();
+  // Shared channel for receiving data from other channel then sending to current connection
+  let (shared_tx, mut shared_rx) = broadcast::channel::<SMessageType>(1003);
 
-  let mut shared_group_tx = {
-    let mut group_txs = app_state.group_txs.lock().await;
-    match group_txs.get(&group_id) {
-      Some(txs) => txs.clone(),
-      None => {
-        let (tx, _rx) = broadcast::channel(1000);
-        group_txs.insert(group_id, tx.clone());
-        tx
-      }
-    }
-  };
-  let mut shared_group_rx = shared_group_tx.subscribe();
-
-  // Propagate message events to all subscribe clients
-  let mut propagate_task = tokio::spawn(async move {
-    while let Ok(msg) = shared_group_rx.recv().await {
+  // Receive all data from shared channel then sending to current connection
+  let mut sending_task = tokio::spawn(async move {
+    while let Ok(msg) = shared_rx.recv().await {
       tracing::debug!("Propagate message from group {group_id} to client");
       if let Err(err) = socket_sender
         .send(Message::Text(serde_json::to_string(&msg).unwrap()))
@@ -98,14 +69,86 @@ pub async fn handle_socket(
       }
     }
   });
+  // Sender and Receiver serve for current connection
+  let (mut current_sender, mut current_receiver) = broadcast::channel::<SMessageType>(3);
+  let share_tx_clone = shared_tx.clone();
+  // Current channel receiver receives data then propagate to shared channel
+  tokio::spawn(async move {
+    while let Ok(msg) = current_receiver.recv().await {
+      let _ = share_tx_clone.send(msg);
+    }
+  });
+
+  // Handle first authentication message
+  let timeout_rs = timeout(Duration::from_secs(10), socket_receiver.next()).await;
+  if let Err(_err) = &timeout_rs {
+    tracing::info!("Client authenticate is timeout");
+    if current_sender
+      .send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+        1,
+        "Authentication Timeout",
+      )))
+      .is_err()
+    {
+      tracing::error!("Failed to send Timeout message to client");
+    }
+  }
+  let first_message_op = timeout_rs.unwrap();
+  if first_message_op.is_none() {
+    tracing::info!("Stream has been closed, so cannot read");
+    return;
+  }
+  let first_message_rs = first_message_op.unwrap();
+  if first_message_rs.is_err() {
+    tracing::info!("Failed to received first authenticate message");
+    return;
+  }
+  let first_message = first_message_rs.unwrap();
+
+  let authenticated_rs = authenticate(
+    first_message,
+    app_state.clone(),
+    group_id,
+    &mut current_sender,
+    &addr,
+  );
+
+  if authenticated_rs.is_err() {
+    return;
+  }
+  let mut group_session = GroupSession {
+    user_id: authenticated_rs.unwrap(),
+    group_id,
+  };
+
+  // Get current group channel
+  let mut shared_group_tx = {
+    let mut group_txs = app_state.group_txs.lock().await;
+    match group_txs.get(&group_id) {
+      Some(txs) => txs.clone(),
+      None => {
+        let (tx, _rx) = broadcast::channel(1000);
+        group_txs.insert(group_id, tx.clone());
+        tx
+      }
+    }
+  };
+  let mut shared_group_rx = shared_group_tx.subscribe();
+  // propagate shared group message to shared channel
+  tokio::spawn(async move {
+    while let Ok(msg) = shared_group_rx.recv().await {
+      let _ = shared_tx.send(msg);
+    }
+  });
   // Received message from client and process message
-  let mut receive_task = tokio::spawn(async move {
+  let mut receiving_task = tokio::spawn(async move {
     while let Some(Ok(msg)) = socket_receiver.next().await {
       if process_message(
         msg,
         addr,
         app_state.clone(),
-        group_session,
+        &mut group_session,
+        &mut current_sender,
         &mut shared_group_tx,
       )
       .is_break()
@@ -117,23 +160,126 @@ pub async fn handle_socket(
   });
   // Abort the other task, if any one of the task exists
   tokio::select! {
-    _p_t = (&mut propagate_task) =>{
-      receive_task.abort();
+    _p_t = (&mut sending_task) =>{
+      receiving_task.abort();
     },
-    _r_t = (&mut receive_task) =>{
-      propagate_task.abort();
+    _r_t = (&mut receiving_task) =>{
+      sending_task.abort();
     }
   }
 }
+/// Authenticate first message
+///
+/// If authenticating successfully the user_id result will be returned, unless return error
+fn authenticate(
+  msg: Message,
+  state: Arc<AppState>,
+  group_id: i32,
+  current_sender: &mut Sender<SMessageType>,
+  addr: &SocketAddr,
+) -> Result<i32, ()> {
+  match msg {
+    Message::Text(raw_str) => {
+      let conn = &mut state.db_pool.get().unwrap();
+      let rs = serde_json::from_slice::<SMessageType>(raw_str.as_bytes());
+      if let Err(err) = rs {
+        tracing::debug!("Not support socket message type: {}", err.to_string());
+        if current_sender
+          .send(SMessageType::UnSupportMessage(
+            "Unsupported Message Format".into(),
+          ))
+          .is_err()
+        {
+          tracing::error!("Failed to send unsupported message type message");
+        }
+        return Err(());
+      }
+      match rs.unwrap() {
+        SMessageType::Authenticate(user_code) => {
+          // Validate user authentication and authorization
+          let user_rs = get_user_by_code(conn, &user_code);
 
+          if let Err(_err) = user_rs {
+            if current_sender
+              .send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+                5,
+                "Failed to get user from user code",
+              )))
+              .is_err()
+            {
+              tracing::error!("Failed to send authenticate result message");
+            };
+            return Err(());
+          }
+          let user_op = user_rs.unwrap();
+          if let None = user_op {
+            if current_sender
+              .send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+                4,
+                "User token is expired or not found".into(),
+              )))
+              .is_err()
+            {
+              tracing::error!("Failed to send authenticate result message");
+            }
+            return Err(());
+          }
+          let user = user_op.unwrap();
+
+          if let Ok(false) = check_user_join_group(conn, user.id, group_id) {
+            if current_sender
+              .send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+                3,
+                "User does not have permission to access this group",
+              )))
+              .is_err()
+            {
+              tracing::error!("Failed to send authenticate result message");
+            };
+            return Err(());
+          }
+
+          if current_sender
+            .send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+              0,
+              "Authenticated Successfully",
+            )))
+            .is_err()
+          {
+            tracing::error!("Failed to send authenticate successfully message");
+          };
+          tracing::debug!("Client {addr} authenticated successfully");
+          return Ok(user.id);
+        }
+
+        _ => {
+          tracing::debug!("Cannot handle message ");
+        }
+      }
+      tracing::debug!(">> {addr} send text message {raw_str:?}");
+    }
+    _ => {
+      tracing::debug!("Only supports authenticated text message type");
+      let _ = current_sender.send(SMessageType::AuthenticateResponse(AuthenticateResult::new(
+        2,
+        "Only supports authenticated text message type",
+      )));
+    }
+  }
+  Err(())
+}
+
+// #[allow(unused)]
 fn process_message(
   msg: Message,
   addr: SocketAddr,
   state: Arc<AppState>,
-  group_session: GroupSession,
+  group_session: &mut GroupSession,
+  current_sender: &mut Sender<SMessageType>,
   shared_group_sender: &mut Sender<SMessageType>,
 ) -> ControlFlow<(), ()> {
   let conn = &mut state.db_pool.get().unwrap();
+
   match msg {
     Message::Ping(v) => {
       tracing::debug!(">> {addr} send ping message {v:?}")
@@ -144,13 +290,20 @@ fn process_message(
     Message::Text(raw_str) => {
       let rs = serde_json::from_slice::<SMessageType>(raw_str.as_bytes());
       if let Err(err) = rs {
-        tracing::debug!("Parse json error: {} ", err.to_string());
-        tracing::debug!("Not support socket message type");
+        tracing::debug!("Not support socket message type: {}", err.to_string());
+        if current_sender
+          .send(SMessageType::UnSupportMessage(
+            "Unsupported Message Format".into(),
+          ))
+          .is_err()
+        {
+          tracing::error!("Failed to send unsupported message type message");
+        }
         return ControlFlow::Break(());
       }
       match rs.unwrap() {
         SMessageType::Send(s_new_message) => {
-          tracing::debug!(">> SEND message: {s_new_message:?}");
+          tracing::debug!(">> Client {addr} SEND message: {s_new_message:?}");
           let insert_message =
             s_new_message.build_new_message(group_session.user_id, group_session.group_id);
           let insertion_rs = create_new_message(conn, insert_message);
@@ -182,16 +335,17 @@ fn process_message(
     }
     Message::Close(frame) => {
       if let Some(cf) = frame {
-        println!(
+        tracing::debug!(
           ">>> {} sent close with code {} and reason `{}`",
-          addr, cf.code, cf.reason
+          addr,
+          cf.code,
+          cf.reason
         );
       } else {
-        println!(">>> {addr} somehow sent close message without CloseFrame");
+        tracing::debug!(">>> {addr} somehow sent close message without CloseFrame");
       }
       return ControlFlow::Break(());
     }
   }
-
   ControlFlow::Continue(())
 }

--- a/src/payloads/socket/SocketMessageTypes.md
+++ b/src/payloads/socket/SocketMessageTypes.md
@@ -1,0 +1,105 @@
+# Socket Message Types's Structure
+
+
+**SMessageType::Authenticate JSON:**
+
+Before a client can send or receive messages from a group, it must authenticate itself to the server using a unique authentication token.
+
+```json
+{
+    "Authenticate": "C9D053830E6A88E565B3A85480A391D9C180CDC48F5313140CD4A1C73223B640"
+}
+```
+
+---
+
+**SMessageType::AuthenticateResponse JSON:**
+
+After the client sends an authentication message, the server responds with an authentication result containing a status code and message.
+
+- `status_code`: Represents the result of the authentication attempt
+  - 0: Authentication successful
+  - 1: Authentication timed out
+  - 2: Unsupported authentication message type
+  - 3: User lacks permission to access the group
+  - 4: User token is expired or invalid
+  - 5: Failed to retrieve user based on provided credentials
+- `message`: A short message to explain the result
+
+```json
+{
+  "AuthenticateResponse": {
+    "status_code": 0,
+    "message": "Authenticated Successfully"
+  }
+}
+```
+
+---
+
+**SMessageType::Send JSON:**
+
+Structure of the "Send" message, used by a client to send a message to a group.
+
+```json
+{
+  "Send": {
+    "message_uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "content": "Hello, World!"
+  }
+}
+```
+
+---
+
+**SMessageType::Receive JSON:**
+
+When a new message is sent to a group, the server sends a "Receive" message to all clients subscribed to that group.
+
+```json
+{
+  "Receive": {
+      "message_uuid": "6739e721-91af-4042-9441-2b7c832d42aa",
+      "user_id": 38,
+      "group_id": 25,
+      "content": "Hello world",
+      "created_at": "2024-11-12T07:32:25.455274+00:00",
+      "status": "Sent"
+  }
+}
+```
+
+---
+
+**SMessageType::Edit JSON:**
+
+The "Edit" message structure, used by the client to modify the content of an existing message in the group.
+
+```json
+{
+  "Edit": {
+    "message_uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "user_id": 1,
+    "group_id": 1,
+    "content": "Hello, Group!",
+    "created_at": "2024-11-08T12:00:00Z",
+    "status": "Sent"
+  }
+}
+```
+
+---
+
+**SMessageType::Delete JSON:**
+
+The "Delete" message structure, which specifies a list of message IDs that the client requests to delete from the group.
+
+```json
+{
+  "Delete": [
+    1,
+    2,
+    3
+  ]
+}
+```

--- a/src/payloads/socket/message.rs
+++ b/src/payloads/socket/message.rs
@@ -5,12 +5,42 @@ use crate::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+/// ## Authentication Result structure
+///
+/// ### Properties:
+/// - `status_code`: status code for result
+///   - 0 : Authentication successfully
+///   - 1 : Authentication timeout
+///   - 2 : UnSupport authenticated message type
+///   - 3 : User does not have permission to access this group
+///   - 4 : User token is expired or not found
+///   - 5 : Failed to get user from user code
+///
+/// - `message`: short message for result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct AuthenticateResult {
+  pub status_code: i32,
+  pub message: String,
+}
+impl AuthenticateResult {
+  pub fn new(status_code: i32, message: &str) -> Self {
+    Self {
+      status_code,
+      message: message.into(),
+    }
+  }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum SMessageType {
+  Authenticate(String),
+  AuthenticateResponse(AuthenticateResult),
   Send(SNewMessage),
   Receive(SMessageContent),
   Edit(SMessageContent),
   Delete(Vec<i32>),
+  UnSupportMessage(String),
 }
 
 #[derive(Serialize, Clone, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Currently, on web platform Websocket apis do not support modifying header before connecting to server, so to be a cross platform application we have to change websocket authentication type base on the payload rather than header


## Socket Message Types's Structure


**SMessageType::Authenticate JSON:**

Before a client can send or receive messages from a group, it must authenticate itself to the server using a unique authentication token.

```json
{
    "Authenticate": "C9D053830E6A88E565B3A85480A391D9C180CDC48F5313140CD4A1C73223B640"
}
```

---

**SMessageType::AuthenticateResponse JSON:**

After the client sends an authentication message, the server responds with an authentication result containing a status code and message.

- `status_code`: Represents the result of the authentication attempt
  - 0: Authentication successful
  - 1: Authentication timed out
  - 2: Unsupported authentication message type
  - 3: User lacks permission to access the group
  - 4: User token is expired or invalid
  - 5: Failed to retrieve user based on provided credentials
- `message`: A short message to explain the result

```json
{
  "AuthenticateResponse": {
    "status_code": 0,
    "message": "Authenticated Successfully"
  }
}
```

---

**SMessageType::Send JSON:**

Structure of the "Send" message, used by a client to send a message to a group.

```json
{
  "Send": {
    "message_uuid": "550e8400-e29b-41d4-a716-446655440000",
    "content": "Hello, World!"
  }
}
```

---

**SMessageType::Receive JSON:**

When a new message is sent to a group, the server sends a "Receive" message to all clients subscribed to that group.

```json
{
  "Receive": {
      "message_uuid": "6739e721-91af-4042-9441-2b7c832d42aa",
      "user_id": 38,
      "group_id": 25,
      "content": "Hello world",
      "created_at": "2024-11-12T07:32:25.455274+00:00",
      "status": "Sent"
  }
}
```

---

**SMessageType::Edit JSON:**

The "Edit" message structure, used by the client to modify the content of an existing message in the group.

```json
{
  "Edit": {
    "message_uuid": "550e8400-e29b-41d4-a716-446655440000",
    "user_id": 1,
    "group_id": 1,
    "content": "Hello, Group!",
    "created_at": "2024-11-08T12:00:00Z",
    "status": "Sent"
  }
}
```

---

**SMessageType::Delete JSON:**

The "Delete" message structure, which specifies a list of message IDs that the client requests to delete from the group.

```json
{
  "Delete": [
    1,
    2,
    3
  ]
}
```
