### PR TITLE
feat(websocket): implement seen messages

### DIFF
--- a/migrations/2024-11-20-add-status-column-to-messages/down.sql
+++ b/migrations/2024-11-20-add-status-column-to-messages/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE messages DROP COLUMN status;
+DROP TYPE IF EXISTS MessageStatusType;

--- a/migrations/2024-11-20-add-status-column-to-messages/up.sql
+++ b/migrations/2024-11-20-add-status-column-to-messages/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+CREATE TYPE MessageStatusType AS ENUM (
+  'NotSent',
+  'Sent',
+  'Seen'
+);
+
+ALTER TABLE messages ADD status MessageStatusType NOT NULL DEFAULT 'Sent';
+COMMENT ON COLUMN messages.status IS 'Store reception status';
+

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -6,6 +6,10 @@ pub mod sql_types {
     pub struct Attachmenttype;
 
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "messagestatustype"))]
+    pub struct Messagestatustype;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "messagetype"))]
     pub struct Messagetype;
 }
@@ -32,15 +36,16 @@ diesel::table! {
         group_code -> Varchar,
         user_id -> Int4,
         approval_require -> Nullable<Bool>,
-        maximum_members -> Nullable<Int4>,
         created_at -> Nullable<Timestamp>,
         expired_at -> Nullable<Timestamp>,
+        maximum_members -> Nullable<Int4>,
     }
 }
 
 diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::Messagetype;
+    use super::sql_types::Messagestatustype;
 
     messages (id) {
         id -> Int4,
@@ -52,6 +57,7 @@ diesel::table! {
         group_id -> Int4,
         message_uuid -> Uuid,
         updated_at -> Nullable<Timestamp>,
+        status -> Messagestatustype,
     }
 }
 

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -1,4 +1,4 @@
-use crate::database::models::{ MessageTypeEnum, NewMessage};
+use crate::database::models::{ MessageStatus, MessageTypeEnum, NewMessage};
 use crate::errors::{ApiError, DBError};
 use crate::extractors::UserToken;
 use crate::payloads::common::{ListResponse, PageRequest, OrderBy};
@@ -73,6 +73,7 @@ pub async fn send_msg(
     message_uuid: msg_request.message_uuid,
     content: Some(msg_request.content.as_str()), // Convert String to &str
     message_type: msg_request.message_type,
+    status: MessageStatus::Sent,
     created_at: Utc::now().naive_utc(),
     user_id: user.id,
     group_id: msg_request.group_id,
@@ -99,6 +100,7 @@ pub async fn send_msg(
     ("group_id" = u32, Path, description = "id of the group"),
     ("message_type" = Option<MessageTypeEnum>,Query, description = "message type enum filter"),
     ("content" = Option<String>, Query,description = "content text filter"),
+    ("status" = Option<MessageStatus>, Query,description = "message status filter"),
     ("from_date" = Option<String>, Query, description = "from created date filter"),
     ("to_date" = Option<String>, Query, description = "to created date filter"),
     ("created_at_sort" = Option<OrderBy>, Query, description = "created at sort by ASC or DESC"),
@@ -118,6 +120,7 @@ pub async fn send_msg(
                     "id": 6,
                     "content": "This is test message 1",
                     "message_type": "TEXT",
+                    "status": "Sent",
                     "created_at": "2012-12-12 12:12:12",
                     "user_id": 44,
                     "user_name": "Linus Torvalds"
@@ -127,6 +130,7 @@ pub async fn send_msg(
                     "id": 7,
                     "content": "This is test message 2",
                     "message_type": "TEXT",
+                    "status": "Sent",
                     "created_at": "2012-12-12 12:12:12",
                     "user_id": 44,
                     "user_name": "Linus Torvalds"

--- a/src/payloads/messages.rs
+++ b/src/payloads/messages.rs
@@ -1,4 +1,4 @@
-use crate::database::models::{Message, MessageTypeEnum};
+use crate::database::models::{Message, MessageStatus, MessageTypeEnum};
 use crate::utils::minors::custom_serde::*;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ pub struct SendMessageResponse {
   pub message_id: i32,
   pub content: String,
   pub message_type: MessageTypeEnum,
+  pub status: MessageStatus,
   #[serde(serialize_with = "serialize_with_date_time_utc")]
   pub created_at: DateTime<Utc>,
 }
@@ -33,6 +34,7 @@ impl From<Message> for SendMessageResponse {
       message_id: value.id,
       content: value.content.unwrap_or_default(),
       message_type: value.message_type,
+      status: value.status,
       created_at: value.created_at.and_utc(),
     }
   }
@@ -49,6 +51,7 @@ pub struct MessageResponse {
   pub id: i32,
   pub content: Option<String>,
   pub message_type: MessageTypeEnum,
+  pub status: MessageStatus,
   #[serde(serialize_with = "serialize_naive_datetime")]
   pub created_at: NaiveDateTime,
   #[serde(serialize_with = "serialize_naive_datetime_option")]
@@ -63,6 +66,7 @@ impl From<Message> for MessageResponse {
       id: value.id,
       content: value.content,
       message_type: value.message_type,
+      status: value.status,
       created_at: value.created_at,
       updated_at: value.updated_at,
       user_id: value.user_id,
@@ -83,6 +87,7 @@ pub struct MessageWithUser {
   pub id: i32,
   pub content: Option<String>,
   pub message_type: MessageTypeEnum,
+  pub status: MessageStatus,
   #[serde(serialize_with = "serialize_naive_datetime")]
   pub created_at: NaiveDateTime,
   #[serde(serialize_with = "serialize_naive_datetime_option")]
@@ -95,6 +100,7 @@ pub struct MessageWithUser {
 pub struct MessageFilterParams {
   pub message_type: Option<MessageTypeEnum>,
   pub content: Option<String>,
+  pub status: Option<MessageStatus>,
   #[serde(
     deserialize_with = "deserialize_with_naive_date_option",
     default = "Option::default"

--- a/src/payloads/socket/SocketMessageTypes.md
+++ b/src/payloads/socket/SocketMessageTypes.md
@@ -1,6 +1,6 @@
 # Socket Message Types's Structure
 
-
+## Authentication
 **SMessageType::Authenticate JSON:**
 
 Before a client can send or receive messages from a group, it must authenticate itself to the server using a unique authentication token.
@@ -34,8 +34,7 @@ After the client sends an authentication message, the server responds with an au
   }
 }
 ```
-
----
+## Send message
 
 **SMessageType::Send JSON:**
 
@@ -51,7 +50,7 @@ Structure of the "Send" message, used by a client to send a message to a group.
 }
 ```
 
----
+
 
 **SMessageType::Receive JSON:**
 
@@ -70,26 +69,7 @@ When a new message is sent to a group, the server sends a "Receive" message to a
 }
 ```
 
----
-
-**SMessageType::Edit JSON:**
-
-The "Edit" message structure, used by the client to modify the content of an existing message in the group.
-
-```json
-{
-  "Edit": {
-    "message_uuid": "550e8400-e29b-41d4-a716-446655440000",
-    "user_id": 1,
-    "group_id": 1,
-    "content": "Hello, Group!",
-    "created_at": "2024-11-08T12:00:00Z",
-    "status": "Sent"
-  }
-}
-```
-
----
+## Delete messages
 
 **SMessageType::DeleteMessage JSON:**
 
@@ -105,6 +85,7 @@ The "Delete" message structure, which specifies a list of message identifiers `m
   }
 }
 ```
+---
 **SMessageType::DeleteMessageResponse JSON:**
 
 After client request a delete message, if an error occurs the Delete message response will be sent from server with a short message to explain the error.
@@ -116,7 +97,7 @@ After client request a delete message, if an error occurs the Delete message res
   }
 }
 ```
-
+---
 **SMessageType::DeleteMessageEvent JSON:**
 The message will be responded from server if a delete message request was processed successfully to inform all connected client in a group.
 
@@ -132,8 +113,7 @@ The message will be responded from server if a delete message request was proces
 }
 ```
 
-
-
+## Edit message
 **SMessageType::EditMessage JSON:**
 
 The "Edit" message structure, which specifies `content`, `message_type` fields are optional, that the client requests to update specific message `message_id`.
@@ -148,6 +128,7 @@ The "Edit" message structure, which specifies `content`, `message_type` fields a
   }
 }
 ```
+---
 **SMessageType::EditMessageResponse JSON:**
 
 After client request a edit message, if an error occurs a edit message response will be sent from server with a short message to explain the error.
@@ -159,7 +140,7 @@ After client request a edit message, if an error occurs a edit message response 
   }
 }
 ```
-
+---
 **SMessageType::EditMessageData JSON:**
 The message will be responded from server if a update message request was processed successfully to inform all connected client in a group.
 
@@ -173,9 +154,50 @@ The message will be responded from server if a update message request was proces
     "content": "That is edited message 42",
     "username": null,
     "message_type": "ATTACHMENT",
+    "status": "Sent",
     "created_at": "2024-11-19T09:25:54.219284+00:00",
     "updated_at": "2024-11-19T09:26:26.979009+00:00",
     "status": "Sent"
   }
 }
 ```
+## Seen Message
+**SMessageType::SeenMessages JSON:**
+The `Seen` message structure which contains list of `messages_ids` that client requests to change status of message to seen
+```json
+{
+  "SeenMessages": {
+      "group_id": 24,
+      "message_ids": [
+          41,42
+      ]
+  }
+}
+```
+---
+**SMessageType::SeenMessagesResponse JSON:**
+After sending a seen message, if any error occurs the seen message response will be sent from server with a short message to explain the error.
+```json
+
+{
+  "SeenMessagesResponse": {
+      "status_code": 4,
+      "message": "One of messages is not belong to group 25"
+  }
+}
+
+```
+---
+**SMessageType::EditMessageData JSON:**
+The message will be responded from server if a seen message request was processed successfully to inform all connected client in a group.
+
+```json
+{
+  "SeenMessagesEvent": [
+    45,
+    46
+  ]
+}
+```
+
+


### PR DESCRIPTION
In this pull request, I have implements changing message status to seen realtime. I added some messages type structures:

**SMessageType::SeenMessages JSON:**
The `Seen` message structure which contains list of `messages_ids` that client requests to change status of message to seen
```json
{
  "SeenMessages": {
      "group_id": 24,
      "message_ids": [
          41,42
      ]
  }
}
```
---
**SMessageType::SeenMessagesResponse JSON:**
After sending a seen message, if any error occurs the seen message response will be sent from server with a short message to explain the error.
```json

{
  "SeenMessagesResponse": {
      "status_code": 4,
      "message": "One of messages is not belong to group 25"
  }
}

```
---
**SMessageType::EditMessageData JSON:**
The message will be responded from server if a seen message request was processed successfully to inform all connected client in a group.

```json
{
  "SeenMessagesEvent": [
    45,
    46
  ]
}
```


